### PR TITLE
Add SLF4J-logger and dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,14 @@
     </properties>
 
     <dependencies>
+        <!-- LOGGING -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- BOILERPLATE CODE -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/io/github/open_code_community/mineapi/MineAPI.java
+++ b/src/main/java/io/github/open_code_community/mineapi/MineAPI.java
@@ -1,7 +1,9 @@
 package io.github.open_code_community.mineapi;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MineAPI {
 
     @Getter
@@ -9,6 +11,6 @@ public class MineAPI {
 
 
     private MineAPI() {
-
+        log.debug("MineAPI was initialized!");
     }
 }


### PR DESCRIPTION
The SLF4J-Logging-Framework offers a unified hook for logging. Users of the library can decide at deployment which binding they want to use and how they'd prefer their logging-messages to be formatted.